### PR TITLE
Add io.github.arso-project.archipel

### DIFF
--- a/io.github.arso-project.archipel/.gitignore
+++ b/io.github.arso-project.archipel/.gitignore
@@ -1,0 +1,6 @@
+squashfs-root
+binaries
+.linglong-target
+Archipel
+@archipelelectron.desktop
+archipel-0.1.0.AppImage

--- a/io.github.arso-project.archipel/Makefile
+++ b/io.github.arso-project.archipel/Makefile
@@ -1,0 +1,54 @@
+.PHONY: all
+all: desktop binary
+
+BINNAME ?= Archipel
+APP_PREFIX ?= archipel
+.PHONY: binary
+binary: $(BINNAME)
+$(BINNAME):
+	echo "#!/usr/bin/env bash" > $(BINNAME)
+	echo "cd /$(PREFIX)/lib/$(APP_PREFIX) && ./AppRun $$@" >> $(BINNAME)
+
+DESKTOP_FILE ?= @archipelelectron.desktop
+.PHONY: desktop
+desktop: extract $(DESKTOP_FILE)
+$(DESKTOP_FILE): squashfs-root/$(DESKTOP_FILE)
+	cp squashfs-root/$(DESKTOP_FILE) .
+	sed -i \
+		"s/Exec=.*/Exec=\/$(subst /,\/,$(PREFIX))\/bin\/$(BINNAME)/" \
+		$(DESKTOP_FILE)
+
+APPIMAGE ?= archipel-0.1.0.AppImage
+.PHONY: extract
+extract: squashfs-root
+squashfs-root: $(APPIMAGE)
+	chmod +x $(APPIMAGE)
+	./$(APPIMAGE) --appimage-extract
+
+APPIMAGE_URL ?= https://github.com/arso-project/archipel/releases/download/v0.1.0/archipel-0.1.0.AppImage
+$(APPIMAGE):
+	wget $(APPIMAGE_URL) -O $(APPIMAGE)
+
+PREFIX ?= opt/apps/$(APP_PREFIX)
+DESTDIR ?=
+.PHONY: install
+install: binary desktop
+	( \
+		cd squashfs-root && \
+		find -type f -exec \
+			install -D "{}" "$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}" \; && \
+		find -type l -exec bash -c " \
+			ln -s \$$(readlink {}) \
+				\"$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}\" \
+		" \; \
+	)
+	install -D $(BINNAME) \
+		$(DESTDIR)/$(PREFIX)/bin/$(BINNAME)
+	install -D $(DESKTOP_FILE) \
+		$(DESTDIR)/$(PREFIX)/share/applications/$(DESKTOP_FILE)
+
+.PHONY: clean
+clean:
+	rm -r squashfs-root || true
+	rm $(DESKTOP_FILE) || true
+	rm $(BINNAME) || true

--- a/io.github.arso-project.archipel/linglong.yaml
+++ b/io.github.arso-project.archipel/linglong.yaml
@@ -1,7 +1,7 @@
 package:
   id: io.github.arso-project.archipel
   name: archipel
-  version: 2.6.0
+  version: 0.1.0
   kind: app
   description: |
     archipel is a decentralized archiving and media library system. 

--- a/io.github.arso-project.archipel/linglong.yaml
+++ b/io.github.arso-project.archipel/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.arso-project.archipel
+  name: archipel
+  version: 2.6.0
+  kind: app
+  description: |
+    archipel is a decentralized archiving and media library system. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: local
+
+build:
+  kind: manual
+  manual:
+    build: |
+      make
+    install: |
+      make install


### PR DESCRIPTION
在这个包的依赖中存在pak类型的文件，在尝试build的过程中出现了以下错误：

strip /opt/apps/io.github.arso-project.archipel/files/lib/archipel/chrome_100_percent.pak to /opt/apps/io.github.arso-project.archipel/files/debug//lib/archipel/chrome_100_percent.pak.debug
eu-strip: /opt/apps/io.github.arso-project.archipel/files/lib/archipel/chrome_100_percent.pak: File format not recognized

 "./src/builder/builder/linglong_builder.cpp:747:buildFlow" 
 "build task failed in container" 
看起来同样是strip过程中的问题，与#1 类似？