### PR TITLE
Add io.github.subsurface

### DIFF
--- a/io.github.subsurface/.gitignore
+++ b/io.github.subsurface/.gitignore
@@ -1,0 +1,6 @@
+squashfs-root
+.linglong-target
+binaries
+Subsurface
+subsurface.desktop
+Subsurface-5.0.10-x86_64.AppImage

--- a/io.github.subsurface/Makefile
+++ b/io.github.subsurface/Makefile
@@ -1,0 +1,55 @@
+.PHONY: all
+all: desktop binary
+
+BINNAME ?= Subsurface
+APP_PREFIX ?= io.github.subsurface
+.PHONY: binary
+binary: $(BINNAME)
+$(BINNAME):
+	echo "#!/usr/bin/env bash" > $(BINNAME)
+	echo "unset LD_LIBRARY_PATH" >> $(BINNAME)
+	echo "cd /$(PREFIX)/lib/$(APP_PREFIX) && ./AppRun $$@" >> $(BINNAME)
+
+DESKTOP_FILE ?= subsurface.desktop
+.PHONY: desktop
+desktop: extract $(DESKTOP_FILE)
+$(DESKTOP_FILE):
+	cp squashfs-root/$(DESKTOP_FILE) .
+	sed -i \
+		"s/Exec=.*/Exec=\/$(subst /,\/,$(PREFIX))\/bin\/$(BINNAME)/" \
+		$(DESKTOP_FILE)
+
+APPIMAGE ?= Subsurface-5.0.10-x86_64.AppImage
+.PHONY: extract
+extract: squashfs-root
+squashfs-root: $(APPIMAGE)
+	chmod +x $(APPIMAGE)
+	./$(APPIMAGE) --appimage-extract
+
+APPIMAGE_URL ?= https://subsurface-divelog.org/downloads/Subsurface-5.0.10-x86_64.AppImage
+$(APPIMAGE):
+	wget $(APPIMAGE_URL) -O $(APPIMAGE)
+
+PREFIX ?= opt/apps/$(APP_PREFIX)
+DESTDIR ?= 
+.PHONY: install
+install: binary desktop
+	( \
+		cd squashfs-root && \
+		find -type f -exec \
+			install -D "{}" "$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}" \; && \
+		find -type l -exec bash -c " \
+			ln -s \$$(readlink {}) \
+				\"$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}\" \
+		" \; \
+	)
+	install -D $(BINNAME) \
+		$(DESTDIR)/$(PREFIX)/bin/$(BINNAME)
+	install -D $(DESKTOP_FILE) \
+		$(DESTDIR)/$(PREFIX)/share/applications/$(DESKTOP_FILE)
+
+.PHONY: clean
+clean:
+	rm -r squashfs-root || true
+	rm $(DESKTOP_FILE) || true
+	rm $(BINNAME) || true

--- a/io.github.subsurface/linglong.yaml
+++ b/io.github.subsurface/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.subsurface
+  name: subsurface
+  version: 5.0.10
+  kind: app
+  description: |
+    Subsurface is an divelog program for recreational, tech, and free-divers.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: local
+
+build:
+  kind: manual
+  manual:
+    build: |
+      make
+    install: |
+      make install

--- a/io.github.subsurface/linglong.yaml
+++ b/io.github.subsurface/linglong.yaml
@@ -20,3 +20,4 @@ build:
       make
     install: |
       make install
+      


### PR DESCRIPTION
To avoid merging problems, I closed Pr #1  (where I tried to merge the master branch in my repository) and opened a new branch for committing Subsurface. I modified the Makefile according to comments in #1 , and now the program works, but the following prompt still appears:

2023-07-04 13:46:30.691 [ll-dbus-proxy] [info] dbus proxy socketPath: "/run/user/1000/.dbus-proxy/session-bus-proxy-AdoqSG"
2023-07-04 13:46:30.691 [ll-dbus-proxy] [critical] user input dbus type err
can't find Qt base localization for locale "zh-CN" searching in "/opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/translations"
can't find Subsurface localization for locale "zh-CN"
qrc:/qml/MapWidget.qml:2:1: plugin cannot be loaded for module "QtQuick": Cannot load library /opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: (/opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: 目标文件没有可加载段)
QUrl("qrc:/qml/MapWidget.qml") failed to load with status: QQuickWidget::Error
qrc:/qml/MapWidgetError.qml:2:1: plugin cannot be loaded for module "QtQuick": Cannot load library /opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: (/opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: 目标文件没有可加载段)
qrc:/qml/statsview2.qml:2:1: plugin cannot be loaded for module "QtQuick": Cannot load library /opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: (/opt/apps/io.github.subsurface/files/lib/io.github.subsurface/usr/qml/QtQuick.2/libqtquick2plugin.so: 目标文件没有可加载段)
Oops. The root of the StatsView is not a StatsView.

1. Can we ignore these prompts until the build tool is fixed?
2. After the build tool is fixed, do we also not need to use workaround: ```unset LD_LIBRARY_PATH```?