### PR TITLE
Add io.github.arduino.arduino-ide

### DIFF
--- a/io.github.arduino.arduino-ide/.gitignore
+++ b/io.github.arduino.arduino-ide/.gitignore
@@ -1,0 +1,7 @@
+squashfs-root
+binaries
+.linglong-target
+Arduino-ide
+arduino-ide.desktop
+arduino-ide_2.1.1_Linux_64bit.AppImage
+

--- a/io.github.arduino.arduino-ide/Makefile
+++ b/io.github.arduino.arduino-ide/Makefile
@@ -1,0 +1,54 @@
+.PHONY: all
+all: desktop binary
+
+BINNAME ?= Arduino-ide
+APP_PREFIX ?= arduino-ide
+.PHONY: binary
+binary: $(BINNAME)
+$(BINNAME):
+	echo "#!/usr/bin/env bash" > $(BINNAME)
+	echo "cd /$(PREFIX)/lib/$(APP_PREFIX) && ./AppRun $$@" >> $(BINNAME)
+
+DESKTOP_FILE ?= arduino-ide.desktop
+.PHONY: desktop
+desktop: extract $(DESKTOP_FILE)
+$(DESKTOP_FILE): squashfs-root/$(DESKTOP_FILE)
+	cp squashfs-root/$(DESKTOP_FILE) .
+	sed -i \
+		"s/Exec=.*/Exec=\/$(subst /,\/,$(PREFIX))\/bin\/$(BINNAME)/" \
+		$(DESKTOP_FILE)
+
+APPIMAGE ?= arduino-ide_2.1.1_Linux_64bit.AppImage
+.PHONY: extract
+extract: squashfs-root
+squashfs-root: $(APPIMAGE)
+	chmod +x $(APPIMAGE)
+	./$(APPIMAGE) --appimage-extract
+
+APPIMAGE_URL ?= https://github.com/arduino/arduino-ide/releases/download/2.1.1/arduino-ide_2.1.1_Linux_64bit.AppImage
+$(APPIMAGE):
+	wget $(APPIMAGE_URL) -O $(APPIMAGE)
+
+PREFIX ?= opt/apps/$(APP_PREFIX)
+DESTDIR ?=
+.PHONY: install
+install: binary desktop
+	( \
+		cd squashfs-root && \
+		find -type f -exec \
+			install -D "{}" "$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}" \; && \
+		find -type l -exec bash -c " \
+			ln -s \$$(readlink {}) \
+				\"$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}\" \
+		" \; \
+	)
+	install -D $(BINNAME) \
+		$(DESTDIR)/$(PREFIX)/bin/$(BINNAME)
+	install -D $(DESKTOP_FILE) \
+		$(DESTDIR)/$(PREFIX)/share/applications/$(DESKTOP_FILE)
+
+.PHONY: clean
+clean:
+	rm -r squashfs-root || true
+	rm $(DESKTOP_FILE) || true
+	rm $(BINNAME) || true

--- a/io.github.arduino.arduino-ide/linglong.yaml
+++ b/io.github.arduino.arduino-ide/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.arduino.arduino-ide
+  name: arduino-ide
+  version: 2.1.1
+  kind: app
+  description: |
+    The Arduino IDE 2.x is a major rewrite, sharing no code with the IDE 1.x. It is based on the Theia IDE framework and built with Electron. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: local
+
+build:
+  kind: manual
+  manual:
+    build: |
+      make
+    install: |
+      make install
+      


### PR DESCRIPTION
When I try to build an arduino-ide project, I got the following error message:

strip /opt/apps/io.github.arduino.arduino-ide/files/lib/arduino-ide/resources/app/plugins/cortex-debug/extension/binary_modules/v12.14.1/win32/ia32/node_modules/@serialport/bindings/build/Release/bindings.exp to /opt/apps/io.github.arduino.arduino-ide/files/debug//lib/arduino-ide/resources/app/plugins/cortex-debug/extension/binary_modules/v12.14.1/win32/ia32/node_modules/@serialport/bindings/build/Release/bindings.exp.debug
eu-strip: /opt/apps/io.github.arduino.arduino-ide/files/lib/arduino-ide/resources/app/plugins/cortex-debug/extension/binary_modules/v12.14.1/win32/ia32/node_modules/@serialport/bindings/build/Release/bindings.exp: File format not recognized

 "./src/builder/builder/linglong_builder.cpp:747:buildFlow" 
 "build task failed in container" 

I guess this is still a strip-related issue which is similar to #5 .