### PR TITLE
Add Discord 0.0.27

### DIFF
--- a/io.github.discord/Makefile
+++ b/io.github.discord/Makefile
@@ -1,0 +1,57 @@
+.PHONY: all
+all: desktop binary
+
+BINNAME ?= Discord
+
+APP_PREFIX ?= Discord
+.PHONY: binary
+binary: $(BINNAME)
+$(BINNAME):
+	echo "#!/usr/bin/env bash" > $(BINNAME)
+	echo "unset LD_LIBRARY_PATH" >> $(BINNAME)
+	echo "cd $(PREFIX)/lib/$(APP_PREFIX) && ./AppRun $$@" >> $(BINNAME)
+
+DESKTOP_FILE ?= $(shell cd squashfs-root && ls *.desktop)
+.PHONY: desktop
+desktop: extract $(DESKTOP_FILE)
+$(DESKTOP_FILE):
+	cp squashfs-root/$(DESKTOP_FILE) .
+	sed -i \
+		"s@Exec=.*@Exec=/$(PREFIX)/bin/$(BINNAME)@" \
+		$(DESKTOP_FILE)
+
+APPIMAGE ?= $(shell  ls *.AppImage)
+.PHONY: extract
+extract: squashfs-root
+squashfs-root: $(APPIMAGE)
+	chmod +x $(APPIMAGE)
+	./$(APPIMAGE) --appimage-extract
+
+APPIMAGE_URL ?= https://github.com/srevinsaju/discord-appimage/releases/download/stable/Discord-0.0.27-x86_64.AppImage
+$(APPIMAGE):
+	wget $(APPIMAGE_URL) -O $(APPIMAGE)
+
+PREFIX ?= opt/$(APP_PREFIX)
+DESTDIR ?=
+.PHONY: install
+
+install: binary desktop
+	( \
+		cd squashfs-root && \
+		find -type f -exec \
+			install -D "{}" "$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}" \; && \
+		find -type l -exec bash -c " \
+			ln -s \$$(readlink {}) \
+				\"$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}\" \
+		" \; \
+	)
+	install -D $(BINNAME) \
+		$(DESTDIR)/$(PREFIX)/bin/$(BINNAME)
+	install -D $(DESKTOP_FILE) \
+		$(DESTDIR)/$(PREFIX)/share/applications/$(DESKTOP_FILE)
+
+.PHONY: clean
+clean:
+	rm -r squashfs-root || true
+	rm $(DESKTOP_FILE) || true
+	rm $(BINNAME) || true

--- a/io.github.discord/linglong.yaml
+++ b/io.github.discord/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.Discord
+  name: 'Discord'
+  version: 0.0.27
+  kind: app
+  description: |
+    This is a rom management tool, specifically designed for use with Retropie & Recalbox, but it works with anything.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: local
+
+build:
+  kind: manual
+  manual:
+    build: |
+      make
+    install: |
+      make install


### PR DESCRIPTION
由于discord的特殊性，在run的时候，首先要校验Runtime，此时不开代理；在运行的时候，需要开代理。
![截图_discord_20230705113502](https://github.com/black-desk/linglong-package-examples/assets/88428681/c99666a8-e54f-4e57-a31c-e72ae0f27229)
