### PR TITLE
Add io.github.qishibo.anotherRedisDesktopManager

### DIFF
--- a/io.github.qishibo.anotherRedisDesktopManager/.gitignore
+++ b/io.github.qishibo.anotherRedisDesktopManager/.gitignore
@@ -1,0 +1,6 @@
+squashfs-root
+.linglong-target
+binaries
+AnotherRedisDesktopManager
+another-redis-desktop-manager.desktop
+Another-Redis-Desktop-Manager.1.6.1.AppImage

--- a/io.github.qishibo.anotherRedisDesktopManager/Makefile
+++ b/io.github.qishibo.anotherRedisDesktopManager/Makefile
@@ -1,0 +1,55 @@
+.PHONY: all
+all: desktop binary
+
+BINNAME ?= AnotherRedisDesktopManager
+APP_PREFIX ?= anotherRedisDesktopManager
+.PHONY: binary
+binary: $(BINNAME)
+$(BINNAME):
+	echo "#!/usr/bin/env bash" > $(BINNAME)
+	echo "unset LD_LIBRARY_PATH" >> $(BINNAME)
+	echo "cd /$(PREFIX)/lib/$(APP_PREFIX) && ./AppRun $$@" >> $(BINNAME)
+
+DESKTOP_FILE ?= another-redis-desktop-manager.desktop
+.PHONY: desktop
+desktop: extract $(DESKTOP_FILE)
+$(DESKTOP_FILE):
+	cp squashfs-root/$(DESKTOP_FILE) .
+	sed -i \
+		"s/Exec=.*/Exec=\/$(subst /,\/,$(PREFIX))\/bin\/$(BINNAME)/" \
+		$(DESKTOP_FILE)
+
+APPIMAGE ?= Another-Redis-Desktop-Manager.1.6.1.AppImage
+.PHONY: extract
+extract: squashfs-root
+squashfs-root: $(APPIMAGE)
+	chmod +x $(APPIMAGE)
+	./$(APPIMAGE) --appimage-extract
+
+APPIMAGE_URL ?= https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.6.1/Another-Redis-Desktop-Manager.1.6.1.AppImage
+$(APPIMAGE):
+	wget $(APPIMAGE_URL) -O $(APPIMAGE)
+
+PREFIX ?= opt/apps/$(APP_PREFIX)
+DESTDIR ?= 
+.PHONY: install
+install: binary desktop
+	( \
+		cd squashfs-root && \
+		find -type f -exec \
+			install -D "{}" "$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}" \; && \
+		find -type l -exec bash -c " \
+			ln -s \$$(readlink {}) \
+				\"$(DESTDIR)/$(PREFIX)/lib/$(APP_PREFIX)/{}\" \
+		" \; \
+	)
+	install -D $(BINNAME) \
+		$(DESTDIR)/$(PREFIX)/bin/$(BINNAME)
+	install -D $(DESKTOP_FILE) \
+		$(DESTDIR)/$(PREFIX)/share/applications/$(DESKTOP_FILE)
+
+.PHONY: clean
+clean:
+	rm -r squashfs-root || true
+	rm $(DESKTOP_FILE) || true
+	rm $(BINNAME) || true

--- a/io.github.qishibo.anotherRedisDesktopManager/linglong.yaml
+++ b/io.github.qishibo.anotherRedisDesktopManager/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.qishibo.anotherRedisDesktopManager
+  name: anotherRedisDesktopManager
+  version: 1.6.1
+  kind: app
+  description: |
+    A faster, better and more stable redis desktop manager, compatible with Linux, windows, mac. What's more, it won't crash when loading massive keys.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: local
+
+build:
+  kind: manual
+  manual:
+    build: |
+      make
+    install: |
+      make install
+      


### PR DESCRIPTION
AnotherRedisDesktopManager can be built and run with success.

![anotherRedisDesktopManager](https://github.com/black-desk/linglong-package-examples/assets/60538386/e98f02bb-3e7c-4dc1-a5ef-aba427322d40)
